### PR TITLE
Remove unused inline-c dev dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,6 @@ xz2            = { version = "0.1.7", features = ["static"], optional = true }
 [build-dependencies]
 cbindgen = "^0.24"
 
-[dev-dependencies]
-inline-c = "0.1"
-
 [package.metadata.capi.pkg_config]
 strip_include_path_components = 1
 


### PR DESCRIPTION
```
$ rg inline_c
[no output]
```