### PR TITLE
Test for header instead of length

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ mod tests {
 
     // Single test generation
     macro_rules! round_trip {
-        ($name:ident($compress_output:ident -> $decompress_output:ident), variant=$variant:ident, compressed_len=$compressed_len:literal, $(, $args:ident)*) => {
+        ($name:ident($compress_output:ident -> $decompress_output:ident), variant=$variant:ident, header=$header:literal, $(, $args:ident)*) => {
             #[test]
             fn $name() {
                 let data = gen_data();
@@ -49,8 +49,8 @@ mod tests {
                         crate::$variant::compress(&mut Cursor::new(data.as_slice()), &mut Cursor::new(&mut compressed) $(, $args)*).unwrap()
                     };
 
-                assert_eq!(compressed_size, $compressed_len);
                 compressed.truncate(compressed_size);
+                assert_eq!(&compressed[..$header.len()], $header);
 
                 let mut decompressed = Vec::new();
 
@@ -71,42 +71,42 @@ mod tests {
 
     // macro to generate each variation of Output::* roundtrip.
     macro_rules! test_variant {
-        ($variant:ident, compressed_len=$compressed_len:literal $(, $args:tt)*) => {
+        ($variant:ident, header=$header:literal $(, $args:tt)*) => {
          #[cfg(test)]
          mod $variant {
             use super::*;
-            round_trip!(roundtrip_compress_via_slice_decompress_via_slice(Slice -> Slice), variant=$variant, compressed_len=$compressed_len, $(, $args)* );
-            round_trip!(roundtrip_compress_via_slice_decompress_via_vector(Slice -> Vector), variant=$variant, compressed_len=$compressed_len, $(, $args)* );
-            round_trip!(roundtrip_compress_via_vector_decompress_via_slice(Vector -> Slice), variant=$variant, compressed_len=$compressed_len, $(, $args)* );
-            round_trip!(roundtrip_compress_via_vector_decompress_via_vector(Vector -> Vector), variant=$variant, compressed_len=$compressed_len, $(, $args)* );
+            round_trip!(roundtrip_compress_via_slice_decompress_via_slice(Slice -> Slice), variant=$variant, header=$header, $(, $args)* );
+            round_trip!(roundtrip_compress_via_slice_decompress_via_vector(Slice -> Vector), variant=$variant, header=$header, $(, $args)* );
+            round_trip!(roundtrip_compress_via_vector_decompress_via_slice(Vector -> Slice), variant=$variant, header=$header, $(, $args)* );
+            round_trip!(roundtrip_compress_via_vector_decompress_via_vector(Vector -> Vector), variant=$variant, header=$header, $(, $args)* );
          }
         }
     }
 
     // Expected compressed_len, subsequent args are supplied to the variant's `compress` call.
     #[cfg(feature = "snappy")]
-    test_variant!(snappy, compressed_len = 2_572_398);
+    test_variant!(snappy, header = b"\xff\x06\x00\x00\x73\x4e\x61\x50\x70\x59");
 
     #[cfg(feature = "gzip")]
-    test_variant!(gzip, compressed_len = 157_192, None);
+    test_variant!(gzip, header = b"\x1f\x8b\x08\x00\x00", None);
 
     #[cfg(feature = "brotli")]
-    test_variant!(brotli, compressed_len = 128, None);
+    test_variant!(brotli, header = b"\xcb\xff", None);
 
     #[cfg(feature = "bzip2")]
-    test_variant!(bzip2, compressed_len = 14_207, None);
+    test_variant!(bzip2, header = b"BZh6", None);
 
     #[cfg(feature = "deflate")]
-    test_variant!(deflate, compressed_len = 157_174, None);
+    test_variant!(deflate, header = b"\xec\xcb\xcb\x09", None);
 
     #[cfg(feature = "zstd")]
-    test_variant!(zstd, compressed_len = 4990, None);
+    test_variant!(zstd, header = b"\x28\xb5\x2f\xfd", None);
 
     #[cfg(feature = "lz4")]
-    test_variant!(lz4, compressed_len = 303_278, None);
+    test_variant!(lz4, header = b"\x04\x22\x4d\x18", None);
 
     #[cfg(feature = "blosc2")]
-    test_variant!(blosc2, compressed_len = 791_923);
+    test_variant!(blosc2, header = b"\x9e\xa8\x62\x32");
 
     #[cfg(feature = "xz")]
     #[allow(non_upper_case_globals)]
@@ -125,5 +125,13 @@ mod tests {
     const opts: Option<crate::xz::LzmaOptions> = None;
 
     #[cfg(feature = "xz")]
-    test_variant!(xz, compressed_len = 8_020, None, format, check, filters, opts);
+    test_variant!(
+        xz,
+        header = b"\xFD\x37\x7A\x58\x5A\x00",
+        None,
+        format,
+        check,
+        filters,
+        opts
+    );
 }


### PR DESCRIPTION
Will close #6 

brotli and deflate which have no deterministic header is a bit weird w/ this but maybe less weird than testing for exact compressed lengths? Opinions @musicinmybrain?