### PR TITLE
Fix the description of the blosc2 module (copied from snappy)

### DIFF
--- a/src/blosc2.rs
+++ b/src/blosc2.rs
@@ -1,4 +1,4 @@
-//! snappy de/compression interface
+//! blosc2 de/compression interface
 
 use ::blosc2::CParams;
 pub use blosc2;


### PR DESCRIPTION
Visible at: https://docs.rs/libcramjam/0.4.5/libcramjam/