### PR TITLE
Update brotli from 3.x to 6.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ wasm32-compat     = ["blosc2-rs/deactivate-zlib-optim"]
 [dependencies]
 libc           = { version = "0.2", optional = true }
 snap           = { version = "^1", optional = true }
-brotli         = { version = "^3", default-features = false, features = ["std", "ffi-api"], optional = true }
+brotli         = { version = "^6", default-features = false, features = ["std", "ffi-api"], optional = true }
 bzip2          = { version = "^0.4", optional = true }
 lz4            = { version = "^1", optional = true }
 flate2         = { version = "^1", optional = true }


### PR DESCRIPTION
https://github.com/dropbox/rust-brotli/blob/6.0.0/README.md

We’re trying to update the `rust-brotli` package in Fedora without introducing a compat package. I found that this did not require any source-code changes in `libcramjam` – `cargo test` still passes with this PR.