### PR TITLE
Update brotli from 6.x to 7.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ wasm32-compat     = ["blosc2-rs/deactivate-zlib-optim"]
 [dependencies]
 libc           = { version = "0.2", optional = true }
 snap           = { version = "^1", optional = true }
-brotli         = { version = "^6", default-features = false, features = ["std", "ffi-api"], optional = true }
+brotli         = { version = "^7", default-features = false, features = ["std", "ffi-api"], optional = true }
 bzip2          = { version = "^0.4", optional = true }
 lz4            = { version = "^1", optional = true }
 flate2         = { version = "^1", optional = true }


### PR DESCRIPTION
There were few changes between 6.0.0 and 7.0.0, and it looks like https://github.com/dropbox/rust-brotli/commit/41cadaabb6c650ae518b30509a5fbe43ca8cfab9 was the only breaking one. I confirmed that `cargo test -F brotli` still passes.