### PR TITLE
Update to cbindgen 0.27

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ xz2            = { version = "0.1.7", optional = true }
 isal-rs        = { version = "^0.5", optional = true, default-features = false }
 
 [build-dependencies]
-cbindgen = "^0.24"
+cbindgen = "^0.27"
 
 [package.metadata.capi.pkg_config]
 strip_include_path_components = 1


### PR DESCRIPTION
https://github.com/mozilla/cbindgen/blob/v0.27.0/CHANGES

Nothing really jumped out at me in the changelog, and `cargo test --workspace` still passes.