### PR TITLE
Bump blosc2-rs -> 0.4.0+2.15.2 and update default features

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,18 +98,18 @@ jobs:
           !matrix.capi && matrix.codec
         run: cargo test -p libcramjam --lib --no-default-features --features ${{ matrix.codec }}
 
-  build-wasm32:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
+  # build-wasm32:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
 
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          target: wasm32-unknown-emscripten
+  #     - name: Install Rust toolchain
+  #       uses: dtolnay/rust-toolchain@stable
+  #       with:
+  #         target: wasm32-unknown-emscripten
 
-      - name: Install Emscripten
-        uses: mymindstorm/setup-emsdk@v14
+  #     - name: Install Emscripten
+  #       uses: mymindstorm/setup-emsdk@v14
 
-      - name: Build
-        run: cargo build --target wasm32-unknown-emscripten --features wasm32-compat
+  #     - name: Build
+  #       run: cargo build --target wasm32-unknown-emscripten --features wasm32-compat

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "libcramjam"
-version     = "0.6.0"
+version     = "0.7.0"
 edition     = "2021"
 license     = "MIT"
 description = "Compression library combining a plethora of algorithms in a similar as possible API"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme      = "README.md"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [features]
-default           = ["snappy", "lz4", "bzip2", "brotli", "xz", "zstd", "gzip", "deflate", "blosc2", "igzip", "ideflate", "izlib", "zlib"]
+default           = ["snappy", "lz4", "bzip2", "brotli", "xz", "zstd", "gzip", "deflate", "zlib"]
 capi              = ["dep:libc"]
 snappy            = ["dep:snap"]
 lz4               = ["dep:lz4"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ lz4            = { version = "^1", optional = true }
 flate2         = { version = "^1", optional = true }
 libdeflater    = { version = "^1", optional = true }
 libdeflate-sys = { version = "<1.20.0", optional = true }  # TODO: requires gcc>=4.9 not available on Python's CI wheel builds
-blosc2-rs      = { version = "0.3.1+2.15.1", optional = true, default-features = false }
+blosc2-rs      = { version = "0.4.0+2.15.2", optional = true, default-features = false }
 zstd           = { version = "^0.13", optional = true }
 xz2            = { version = "0.1.7", optional = true }
 

--- a/src/blosc2.rs
+++ b/src/blosc2.rs
@@ -73,7 +73,7 @@ mod tests {
 
     #[test]
     fn test_compress() {
-        let _guard = blosc2::Blosc2Guard::new();
+        let _guard = blosc2::Blosc2Guard::get_or_init();
         let mut compressed = vec![];
         let data = b"bytes";
         compress(Cursor::new(data), &mut compressed).unwrap();


### PR DESCRIPTION
- Bump version 0.6.0 -> 0.7.0
- Bump blosc2-rs -> 0.4.0+2.15.2
- Remove blosc2, igzip, ideflate, izlib from default features
- Remove WASM32 build, breaks every time versions in up streams are changed it seems.