### PR TITLE
Remove cbindgen from build-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,9 +72,6 @@ xz2            = { version = "0.1.7", optional = true }
 [target.'cfg(target_pointer_width = "64")'.dependencies]
 isal-rs        = { version = "^0.5", optional = true, default-features = false }
 
-[build-dependencies]
-cbindgen = "^0.27"
-
 [package.metadata.capi.pkg_config]
 strip_include_path_components = 1
 


### PR DESCRIPTION
While `cargo cbuild` does use `cbindgen` to build header files, `build.rs` doesn’t, and we don’t need a direct dependency on it.