### PR TITLE
Allow building with both bzip2 v0.4 and v0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ wasm32-compat     = ["blosc2-rs/deactivate-zlib-optim"]
 libc           = { version = "0.2", optional = true }
 snap           = { version = "^1", optional = true }
 brotli         = { version = "^7", default-features = false, features = ["std", "ffi-api"], optional = true }
-bzip2          = { version = "^0.4", optional = true }
+bzip2          = { version = ">=0.4,<0.6", optional = true }
 lz4            = { version = "^1", optional = true }
 flate2         = { version = "^1", optional = true }
 libdeflater    = { version = "^1", optional = true }


### PR DESCRIPTION
The only "breaking" changes between v0.4 and v0.5 are bump to the 2021 Edition / MSRV 1.65 (which this crate already has), and some dropped obsolete feature flags (that this crate already didn't use):

https://github.com/trifectatechfoundation/bzip2-rs/releases/tag/v0.5.0